### PR TITLE
feat(core): add point cloud types and Engine trait

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3,5 +3,14 @@
 version = 4
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "sensor-studio-core"
 version = "0.1.0"
+dependencies = [
+ "bytes",
+]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bytes = "1.11.1"

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1,0 +1,11 @@
+use bytes::Bytes;
+
+use crate::types::PointCloudFrame;
+
+pub type EngineId = String;
+
+pub trait Engine {
+    fn id(&self) -> &str;
+
+    fn process(&mut self, chunk: Bytes) -> Vec<PointCloudFrame>;
+}

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -1,0 +1,3 @@
+pub mod pointcloud;
+
+pub use pointcloud::{PointCloudFrame, PointField, PointFieldDataType};

--- a/core/src/types/pointcloud.rs
+++ b/core/src/types/pointcloud.rs
@@ -1,0 +1,64 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PointField {
+    pub name: String,
+    pub offset: u32,
+    pub datatype: PointFieldDataType,
+    pub count: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PointFieldDataType {
+    Int8 = 1,
+    Uint8 = 2,
+    Int16 = 3,
+    Uint16 = 4,
+    Int32 = 5,
+    Uint32 = 6,
+    Float32 = 7,
+    Float64 = 8,
+}
+
+#[derive(Clone, Debug)]
+pub struct PointCloudFrame {
+    pub timestamp_ns: u64,
+    pub frame_id: String,
+    pub width: u32,
+    pub height: u32,
+    pub point_step: u32,
+    pub row_step: u32,
+    pub fields: Vec<PointField>,
+    pub is_dense: bool,
+    pub data: Vec<u8>,
+}
+
+impl PointCloudFrame {
+    pub fn new(
+        timestamp_ns: u64,
+        frame_id: impl Into<String>,
+        width: u32,
+        height: u32,
+        point_step: u32,
+        fields: Vec<PointField>,
+        is_dense: bool,
+        data: Vec<u8>,
+    ) -> Self {
+        let row_step = width.saturating_mul(point_step);
+
+        Self {
+            timestamp_ns,
+            frame_id: frame_id.into(),
+            width,
+            height,
+            point_step,
+            row_step,
+            fields,
+            is_dense,
+            data,
+        }
+    }
+
+    pub fn point_count(&self) -> u32 {
+        self.width.saturating_mul(self.height)
+    }
+}


### PR DESCRIPTION
- 데이터 처리를 위해 `bytes` 크레이트 의존성 추가
- 바이트 청크를 포인트 클라우드 프레임으로 변환하는 `Engine` trait 정의
- 포인트 클라우드 데이터 타입 구현

closes #6 