### PR TITLE
feat(core): define transport interfaces

### DIFF
--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -1,0 +1,19 @@
+use bytes::Bytes;
+
+pub type TransportId = String;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransportKind {
+    Udp,
+    Tcp,
+    Usb,
+    Serial,
+}
+
+pub trait Transport {
+    fn id(&self) -> &str;
+
+    fn kind(&self) -> TransportKind;
+
+    fn read_chunk(&mut self) -> Option<Bytes>;
+}


### PR DESCRIPTION
- 네트워크 및 장치 통신 방식(Udp, Tcp, Usb, Serial)을 표현하는 `TransportKind` 열거형 추가
- 바이트 청크를 읽기 위한 공통 인터페이스 `Transport` trait 추가
- Transport 식별을 위한 `TransportId` 타입 별칭 정의

closes #10 