### PR TITLE
feat(core): integrate instance with engine and udp transport

### DIFF
--- a/core/src/instance/mod.rs
+++ b/core/src/instance/mod.rs
@@ -1,5 +1,9 @@
-use crate::engine::EngineId;
 use std::collections::HashMap;
+use std::io;
+
+use crate::engine::Engine;
+use crate::transport::udp::UdpTransport;
+use crate::types::PointCloudFrame;
 
 pub type InstanceId = String;
 
@@ -11,20 +15,43 @@ pub enum InstanceState {
     Error,
 }
 
-#[derive(Clone, Debug)]
 pub struct Instance {
     pub id: InstanceId,
-    pub engine_id: EngineId,
     pub state: InstanceState,
+    engine: Box<dyn Engine>,
+    transport: UdpTransport,
 }
 
 impl Instance {
-    pub fn new(id: impl Into<String>, engine_id: EngineId) -> Self {
+    pub fn new(id: impl Into<String>, engine: Box<dyn Engine>, transport: UdpTransport) -> Self {
         Self {
             id: id.into(),
-            engine_id,
             state: InstanceState::Created,
+            engine,
+            transport,
         }
+    }
+
+    pub fn engine_id(&self) -> &str {
+        self.engine.id()
+    }
+
+    pub fn transport_id(&self) -> &str {
+        self.transport.id()
+    }
+
+    pub async fn run_once(&mut self) -> io::Result<Vec<PointCloudFrame>> {
+        match self.transport.read_chunk().await? {
+            Some((_sender_addr, chunk)) => {
+                let frames = self.engine.process(chunk);
+                Ok(frames)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub fn set_state(&mut self, state: InstanceState) {
+        self.state = state;
     }
 }
 
@@ -56,8 +83,8 @@ impl InstanceManager {
         self.instances.remove(id)
     }
 
-    pub fn list(&self) -> Vec<&Instance> {
-        self.instances.values().collect()
+    pub fn ids(&self) -> Vec<&str> {
+        self.instances.keys().map(|k| k.as_str()).collect()
     }
 
     pub fn count(&self) -> usize {


### PR DESCRIPTION
- `Instance`가 `Engine`과 `UdpTransport`를 소유하도록 구조 확장
- `run_once()`를 추가해 transport 입력을 engine 처리로 연결
- `InstanceManager`를 실행 단위 관리 구조에 맞게 정리

closes #14 