### PR TITLE
refactor(core): add channel registry for Foxglove topics

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -7,12 +7,14 @@ mod transport;
 mod types;
 
 use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
 use crate::engine::mock::MockEngine;
 use crate::instance::Instance;
 use crate::stream::StreamPublisher;
+use crate::stream::channel::ChannelRegistry;
 use crate::stream::websocket::{
     WebSocketMessage, WebSocketPublisher, WebSocketServer, WebSocketServerState,
 };
@@ -25,8 +27,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (sender, _) = broadcast::channel::<WebSocketMessage>(32);
 
+    let channel_registry = Arc::new(ChannelRegistry::mock_pointcloud());
+
     let ws_state = WebSocketServerState {
         sender: sender.clone(),
+        channel_registry,
     };
 
     tokio::spawn(async move {

--- a/core/src/stream/channel.rs
+++ b/core/src/stream/channel.rs
@@ -1,0 +1,45 @@
+#[derive(Clone, Debug)]
+pub struct ChannelDescriptor {
+    pub id: u32,
+    pub topic: &'static str,
+    pub message_kind: ChannelMessageKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelMessageKind {
+    PointCloud,
+    Status,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChannelRegistry {
+    channels: Vec<ChannelDescriptor>,
+}
+
+impl ChannelRegistry {
+    pub fn new(channels: Vec<ChannelDescriptor>) -> Self {
+        Self { channels }
+    }
+
+    pub fn mock_pointcloud() -> Self {
+        Self::new(vec![ChannelDescriptor {
+            id: 1,
+            topic: "/pointcloud/mock",
+            message_kind: ChannelMessageKind::PointCloud,
+        }])
+    }
+
+    pub fn channels(&self) -> &[ChannelDescriptor] {
+        &self.channels
+    }
+
+    pub fn contains(&self, channel_id: u32) -> bool {
+        self.channels.iter().any(|channel| channel.id == channel_id)
+    }
+
+    pub fn get(&self, channel_id: u32) -> Option<&ChannelDescriptor> {
+        self.channels
+            .iter()
+            .find(|channel| channel.id == channel_id)
+    }
+}

--- a/core/src/stream/mod.rs
+++ b/core/src/stream/mod.rs
@@ -1,3 +1,4 @@
+pub mod channel;
 pub mod console;
 pub mod publisher;
 pub mod websocket;

--- a/core/src/stream/websocket/foxglove/mod.rs
+++ b/core/src/stream/websocket/foxglove/mod.rs
@@ -4,6 +4,7 @@ pub mod protocol;
 pub use crate::stream::websocket::foxglove::encoder::{
     encode_point_cloud_payload, make_message_data_frame,
 };
+
 pub use crate::stream::websocket::foxglove::protocol::{
     FOXGLOVE_SUBPROTOCOL, FoxgloveClientCommand, FoxgloveClientMessage, foxglove_advertise_message,
     foxglove_server_info_message,

--- a/core/src/stream/websocket/foxglove/protocol.rs
+++ b/core/src/stream/websocket/foxglove/protocol.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
+
+use crate::stream::channel::{ChannelDescriptor, ChannelMessageKind, ChannelRegistry};
 
 pub const FOXGLOVE_SUBPROTOCOL: &str = "foxglove.websocket.v1";
 
@@ -14,18 +16,39 @@ pub fn foxglove_server_info_message() -> String {
     .to_string()
 }
 
-pub fn foxglove_advertise_message() -> String {
-    json!({
-        "op": "advertise",
-        "channels": [
-            {
-                "id": 1,
-                "topic": "/pointcloud/mock",
+fn channel_to_foxglove_advertise(channel: &ChannelDescriptor) -> Value {
+    match channel.message_kind {
+        ChannelMessageKind::PointCloud => {
+            json!({
+                "id": channel.id,
+                "topic": channel.topic,
                 "encoding": "json",
                 "schemaName": "foxglove.PointCloud",
-                "schema": ""
-            }
-        ]
+                "schema": "",
+            })
+        }
+        ChannelMessageKind::Status => {
+            json!({
+                "id": channel.id,
+                "topic": channel.topic,
+                "encoding": "json",
+                "schemaName": "foxglove.RawMessage",
+                "schema": "",
+            })
+        }
+    }
+}
+
+pub fn foxglove_advertise_message(registry: &ChannelRegistry) -> String {
+    let channels = registry
+        .channels()
+        .iter()
+        .map(channel_to_foxglove_advertise)
+        .collect::<Vec<_>>();
+
+    json!({
+        "op": "advertise",
+        "channels": channels,
     })
     .to_string()
 }

--- a/core/src/stream/websocket/server.rs
+++ b/core/src/stream/websocket/server.rs
@@ -10,6 +10,7 @@ use axum::routing::get;
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{Mutex, broadcast};
 
+use crate::stream::channel::ChannelRegistry;
 use crate::stream::websocket::WebSocketMessage;
 use crate::stream::websocket::foxglove::{
     FOXGLOVE_SUBPROTOCOL, FoxgloveClientCommand, FoxgloveClientMessage, encode_point_cloud_payload,
@@ -19,6 +20,7 @@ use crate::stream::websocket::foxglove::{
 #[derive(Clone)]
 pub struct WebSocketServerState {
     pub sender: broadcast::Sender<WebSocketMessage>,
+    pub channel_registry: Arc<ChannelRegistry>,
 }
 
 pub struct WebSocketServer;
@@ -45,10 +47,20 @@ impl WebSocketServer {
         ws: WebSocketUpgrade,
     ) -> Response {
         ws.protocols([FOXGLOVE_SUBPROTOCOL])
-            .on_upgrade(move |socket| Self::handle_socket(socket, state.sender.subscribe()))
+            .on_upgrade(move |socket| {
+                Self::handle_socket(
+                    socket,
+                    state.sender.subscribe(),
+                    state.channel_registry.clone(),
+                )
+            })
     }
 
-    async fn handle_socket(socket: WebSocket, receiver: broadcast::Receiver<WebSocketMessage>) {
+    async fn handle_socket(
+        socket: WebSocket,
+        receiver: broadcast::Receiver<WebSocketMessage>,
+        channel_registry: Arc<ChannelRegistry>,
+    ) {
         let (mut sender, mut incoming) = socket.split();
 
         if sender
@@ -60,7 +72,9 @@ impl WebSocketServer {
         }
 
         if sender
-            .send(Message::Text(foxglove_advertise_message().into()))
+            .send(Message::Text(
+                foxglove_advertise_message(channel_registry.as_ref()).into(),
+            ))
             .await
             .is_err()
         {
@@ -85,7 +99,7 @@ impl WebSocketServer {
                         let subscriptions = send_subscriptions.lock().await;
 
                         for (subscription_id, channel_id) in subscriptions.iter() {
-                            if *channel_id != 1 {
+                            if !channel_registry.contains(*channel_id) {
                                 continue;
                             }
 


### PR DESCRIPTION
- channel registry 구조를 추가함
- Foxglove advertise path가 channel registry를 사용하도록 수정함
- subscription 처리에서 유효 channel을 registry 기반으로 확인하도록 정리함