### PR TITLE
feat(core): add engine runtime config for instance setup

### DIFF
--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -3,8 +3,20 @@ use std::net::{Ipv4Addr, SocketAddr};
 #[derive(Clone, Debug)]
 pub struct InstanceRuntimeConfig {
     pub instance_id: String,
+    pub engine: EngineRuntimeConfig,
     pub transport: TransportRuntimeConfig,
     pub channel: InstanceChannelConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct EngineRuntimeConfig {
+    pub kind: EngineKindConfig,
+    pub id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EngineKindConfig {
+    Mock,
 }
 
 #[derive(Clone, Debug)]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -12,8 +12,9 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use crate::config::{
-    ChannelEncoderConfig, ChannelSchemaConfig, InstanceChannelConfig, InstanceRuntimeConfig,
-    TransportRuntimeConfig, UdpTransportRuntimeConfig,
+    ChannelEncoderConfig, ChannelSchemaConfig, EngineKindConfig, EngineRuntimeConfig,
+    InstanceChannelConfig, InstanceRuntimeConfig, TransportRuntimeConfig,
+    UdpTransportRuntimeConfig,
 };
 use crate::engine::mock::MockEngine;
 use crate::instance::Instance;
@@ -32,6 +33,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let instance_configs = vec![InstanceRuntimeConfig {
         instance_id: "instance-1".to_string(),
+        engine: EngineRuntimeConfig {
+            kind: EngineKindConfig::Mock,
+            id: "mock-engine".to_string(),
+        },
         transport: TransportRuntimeConfig::Udp(UdpTransportRuntimeConfig {
             bind_addr: "0.0.0.0:5000".parse()?,
             buffer_size: 4096,
@@ -68,7 +73,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let engine = Box::new(MockEngine::new("mock-engine"));
+    let engine = match &instance_config.engine.kind {
+        EngineKindConfig::Mock => Box::new(MockEngine::new(&instance_config.engine.id)),
+    };
+
     let mut instance = Instance::new(instance_config.instance_id.clone(), engine, transport);
 
     let mut publisher = WebSocketPublisher::new(sender.clone(), publish_source_id);


### PR DESCRIPTION
- instance runtime config가 engine 설정을 표현할 수 있도록 확장
- engine kind를 runtime config에서 다룰 수 있는 구조를 추가
- main의 instance setup이 engine runtime config를 사용하도록 수정