### PR TITLE
fix(core): bound websocket outbound queue for slow clients

### DIFF
--- a/core/src/stream/websocket/server.rs
+++ b/core/src/stream/websocket/server.rs
@@ -95,7 +95,7 @@ impl WebSocketServer {
             return;
         }
 
-        let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Message>(64);
 
         tokio::spawn(async move {
             while let Some(message) = out_rx.recv().await {
@@ -133,7 +133,18 @@ impl WebSocketServer {
                             let binary =
                                 make_message_data_frame(*subscription_id, timestamp_ns, &payload);
 
-                            let _ = out_tx_clone.send(Message::Binary(binary.into()));
+                            if let Err(err) = out_tx_clone.try_send(Message::Binary(binary.into()))
+                            {
+                                if let tokio::sync::mpsc::error::TrySendError::Full(_) = err {
+                                    eprintln!(
+                                        "websocket outbound queue full for client. dropping frame for subscription_id={}",
+                                        *subscription_id
+                                    );
+                                } else {
+                                    // 채널이 닫혔을 때(Closed 오류 등)
+                                    break;
+                                }
+                            }
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(count)) => {
@@ -194,6 +205,7 @@ impl WebSocketServer {
                                     {
                                         if out_tx_clone
                                             .send(Message::Text(response.into()))
+                                            .await
                                             .is_err()
                                         {
                                             return;


### PR DESCRIPTION
- `unbounded_channel`을 크기가 제한된(64) `channel`로 교체하여 서버 OOM(Out of Memory) 방지
- 클라이언트 수신이 느려 outbound 큐가 가득 찬 경우 대기하지 않고 `try_send`로 프레임을 Drop하도록 처리
- 실시간 센서 데이터 특성에 맞게 과거 데이터를 버리고 최신 데이터를 우선 전송하도록 개선