### PR TITLE
build(core): add docker-based multi-arch build environment for core

### DIFF
--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/core/.dockerignore
+++ b/core/.dockerignore
@@ -1,0 +1,5 @@
+target
+.git
+.gitignore
+Dockerfile
+build.sh

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,5 +1,6 @@
 # Rust build
 /target
+/dist
 
 # IDE
 .vscode/

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN apt-get update -o Acquire::Retries=5 && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    pkg-config \
+    gcc-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+RUN rustup target add x86_64-unknown-linux-gnu
+RUN rustup target add aarch64-unknown-linux-gnu
+
+WORKDIR /work

--- a/core/build.sh
+++ b/core/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="sensor-studio-core-builder"
+APP_NAME="sensor-studio-core"
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+DIST_DIR="dist"
+
+if [[ -z "$VERSION" ]]; then
+  echo "[ERROR] failed to read version from Cargo.toml"
+  exit 1
+fi
+
+docker build -t "$IMAGE_NAME" .
+
+docker run --rm \
+  --mount type=bind,src="$(pwd)",dst=/work \
+  -w /work \
+  "$IMAGE_NAME" \
+  cargo build --target x86_64-unknown-linux-gnu --release
+
+docker run --rm \
+  --mount type=bind,src="$(pwd)",dst=/work \
+  -w /work \
+  "$IMAGE_NAME" \
+  cargo build --target aarch64-unknown-linux-gnu --release
+
+mkdir -p "$DIST_DIR"
+
+cp "target/x86_64-unknown-linux-gnu/release/$APP_NAME" \
+   "$DIST_DIR/${APP_NAME}-v${VERSION}-linux-x86_64"
+
+cp "target/aarch64-unknown-linux-gnu/release/$APP_NAME" \
+   "$DIST_DIR/${APP_NAME}-v${VERSION}-linux-aarch64"
+
+echo "[INFO] artifacts created:"
+echo "  - $DIST_DIR/${APP_NAME}-v${VERSION}-linux-x86_64"
+echo "  - $DIST_DIR/${APP_NAME}-v${VERSION}-linux-aarch64"


### PR DESCRIPTION
- Linux x86_64 / aarch64 타겟용 linker 설정을 .cargo/config.toml에 추가
- Rust 및 cross toolchain이 포함된 core 전용 Docker 빌드 환경을 신규 구성
- build.sh를 추가해 Docker 기반으로 release 바이너리를 빌드하고 dist/ 산출물로 복사하도록 정리