### PR TITLE
feat(core): add engine logger callback support for FFI plugins

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let timer = ChronoLocal::new("%Y-%m-%d %H:%M:%S%.3f".to_string());
 
     // 콘솔/파일 환경변수 분리 필터 구성
-    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "trace".into());
+    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "debug".into());
     let file_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| "sensor_studio_core=info".into());
 

--- a/core/src/runtime/factory.rs
+++ b/core/src/runtime/factory.rs
@@ -1,13 +1,55 @@
 //! 주요 런타임 요소 생성 팩토리 함수 모듈
 
+use std::ffi::{CStr, c_char};
 use std::sync::{Arc, Mutex};
 
 use crate::config::{InstanceRuntimeConfig, TransportRuntimeConfig};
 use crate::engine::Engine;
 use crate::runtime::adapter::{FfiEngineAdapter, SharedFfiEngineAdapter};
 use crate::runtime::extensions::SharedEngineExtension;
+use crate::runtime::ffi::{FFI_STATUS_OK, FfiLogLevel};
 use crate::runtime::loader::EngineLibrary;
 use crate::transport::udp::{UdpTransport, UdpTransportConfig};
+
+unsafe extern "C" fn engine_log_callback(
+    level: FfiLogLevel,
+    target_ptr: *const c_char,
+    message_ptr: *const c_char,
+) {
+    if message_ptr.is_null() {
+        return;
+    }
+
+    let target = if target_ptr.is_null() {
+        "engine"
+    } else {
+        unsafe { CStr::from_ptr(target_ptr) }
+            .to_str()
+            .unwrap_or("engine")
+    };
+
+    let message = unsafe { CStr::from_ptr(message_ptr) }
+        .to_string_lossy()
+        .into_owned();
+
+    match level {
+        FfiLogLevel::Error => {
+            tracing::error!("[{}]: {}", target, message)
+        }
+        FfiLogLevel::Warn => {
+            tracing::warn!("[{}]: {}", target, message)
+        }
+        FfiLogLevel::Info => {
+            tracing::info!("[{}]: {}", target, message)
+        }
+        FfiLogLevel::Debug => {
+            tracing::debug!("[{}]: {}", target, message)
+        }
+        FfiLogLevel::Trace => {
+            tracing::trace!("[{}]: {}", target, message)
+        }
+    }
+}
 
 /// 설정 파일 기반 FFI 엔진 어댑터 객체 초기화 및 생성
 pub fn build_engine_extension_adapter(
@@ -15,6 +57,18 @@ pub fn build_engine_extension_adapter(
 ) -> Result<SharedEngineExtension, Box<dyn std::error::Error>> {
     let engine_config = &config.engine;
     let library = unsafe { EngineLibrary::load(&engine_config.library_path)? };
+
+    // logger callback 등록
+    let set_logger_status =
+        unsafe { (library.set_logger)(Some(engine_log_callback), FfiLogLevel::Debug) };
+
+    if set_logger_status != FFI_STATUS_OK {
+        return Err(format!(
+            "failed to register engine logger for '{}': status={set_logger_status}",
+            config.engine.id
+        )
+        .into());
+    }
 
     let unified_config = serde_json::json!({
         "id": config.engine.id,

--- a/core/src/runtime/ffi.rs
+++ b/core/src/runtime/ffi.rs
@@ -87,3 +87,19 @@ pub type EngineCallApiFn = unsafe extern "C" fn(
 ) -> c_int;
 
 pub type EngineFreeApiBufferFn = unsafe extern "C" fn(buffer: *mut FfiApiBuffer);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FfiLogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
+pub type FfiLogCallback =
+    unsafe extern "C" fn(level: FfiLogLevel, target_ptr: *const c_char, message_ptr: *const c_char);
+
+pub type EngineSetLoggerFn =
+    unsafe extern "C" fn(callback: Option<FfiLogCallback>, level: FfiLogLevel) -> i32;

--- a/core/src/runtime/loader.rs
+++ b/core/src/runtime/loader.rs
@@ -3,7 +3,7 @@ use libloading::Library;
 use crate::runtime::ffi::{
     EngineCallApiFn, EngineCreateFn, EngineDestroyFn, EngineFreeApiBufferFn, EngineFreeFrameFn,
     EngineGetApiCountFn, EngineGetApiInfoFn, EngineHasFrameFn, EnginePopFrameFn,
-    EngineProcessPacketFn,
+    EngineProcessPacketFn, EngineSetLoggerFn,
 };
 
 /// 외부 공유 라이브러리 핸들 및 FFI 함수 포인터 구조체
@@ -19,6 +19,7 @@ pub struct EngineLibrary {
     pub get_api_info: EngineGetApiInfoFn,
     pub call_api: EngineCallApiFn,
     pub free_api_buffer: EngineFreeApiBufferFn,
+    pub set_logger: EngineSetLoggerFn,
 }
 
 impl EngineLibrary {
@@ -41,6 +42,8 @@ impl EngineLibrary {
         let free_api_buffer =
             unsafe { *library.get::<EngineFreeApiBufferFn>(b"engine_free_api_buffer")? };
 
+        let set_logger = unsafe { *library.get::<EngineSetLoggerFn>(b"engine_set_logger")? };
+
         Ok(Self {
             _library: library,
             create,
@@ -53,6 +56,7 @@ impl EngineLibrary {
             get_api_info,
             call_api,
             free_api_buffer,
+            set_logger,
         })
     }
 }


### PR DESCRIPTION
- FFI 로그 레벨 및 logger callback 타입을 추가하고, engine library 로더가 engine_set_logger 심볼을 바인딩하도록 확장
- Core 초기화 시 엔진 logger callback 을 등록해 .so 내부 로그를 Core의 tracing 로깅 경로로 전달할 수 있도록 구성
- 기본 콘솔 로그 필터를 trace에서 debug로 조정해 일반 실행 시 로그 노이즈를 낮춤