### PR TITLE
feat: add USB control transfer support

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -36,9 +36,9 @@ pub trait Engine: Send {
         Ok(None)
     }
 
-    /// 종료 시 transport로 전송할 엔진 고유 페이로드 반환
-    /// `engine_get_shutdown_payload` FFI 심볼을 제공하는 경우 유효
-    fn shutdown_payload(&self) -> Option<Bytes> {
+    /// 종료 시 transport로 전송할 엔진 고유 request payload를 반환
+    /// `engine_get_shutdown_request` FFI 심볼을 제공하는 경우 유효
+    fn pop_shutdown_request(&self) -> Option<TransportRequest> {
         None
     }
 }

--- a/core/src/instance/mod.rs
+++ b/core/src/instance/mod.rs
@@ -7,7 +7,7 @@
 use std::io;
 
 use crate::engine::Engine;
-use crate::transport::{Transport, TransportRequest, TransportResponseMode};
+use crate::transport::Transport;
 use crate::types::PointCloudFrame;
 
 /// 인스턴스 고유 식별자
@@ -104,19 +104,20 @@ impl Instance {
 
     /// transport shutdown 패킷 전송 (엔진이 shutdown_payload를 제공하는 경우)
     pub async fn shutdown(&mut self) {
-        if let Some(payload) = self.engine.shutdown_payload() {
-            let request = TransportRequest {
-                data: payload,
-                response_mode: TransportResponseMode::None,
-            };
+        loop {
+            if let Some(shutdown_request) = self.engine.pop_shutdown_request() {
+                tracing::info!("Instance '{}' sending shutdown payload", self.id);
 
-            tracing::info!("Instance '{}' sending shutdown payload", self.id);
+                if let Err(error) = self.transport.transact_chunk(shutdown_request).await {
+                    tracing::warn!(
+                        "Instance '{}' failed to send shutdown payload: {error}",
+                        self.id
+                    );
 
-            if let Err(error) = self.transport.transact_chunk(request).await {
-                tracing::warn!(
-                    "Instance '{}' failed to send shutdown payload: {error}",
-                    self.id
-                );
+                    break;
+                }
+            } else {
+                break;
             }
         }
     }

--- a/core/src/runtime/adapter.rs
+++ b/core/src/runtime/adapter.rs
@@ -7,10 +7,10 @@ use bytes::Bytes;
 use crate::engine::{Engine, EngineProcessResult};
 use crate::runtime::ffi::{
     EngineHandle, FFI_STATUS_OK, FfiApiBuffer, FfiApiInfo, FfiPointCloudFrame, FfiTransportRequest,
-    FfiTransportResponseMode,
+    FfiTransportResponseMode, FfiTransportWriteMode,
 };
 use crate::runtime::loader::EngineLibrary;
-use crate::transport::{TransportRequest, TransportResponseMode};
+use crate::transport::{TransportRequest, TransportResponseMode, TransportWriteMode};
 use crate::types::pointcloud::{PointCloudFrame, PointField, PointFieldDataType};
 
 /// 엔진이 제공하는 동적 제어/설정 API(Extension API) 메타데이터
@@ -286,6 +286,7 @@ impl FfiEngineAdapter {
             data_len: 0,
             response_mode: FfiTransportResponseMode::None,
             response_count: 0,
+            write_mode: FfiTransportWriteMode::Bulk,
         };
 
         let status = unsafe { pop_fn(self.handle, &mut ffi_request) };
@@ -301,6 +302,11 @@ impl FfiEngineAdapter {
                 TransportResponseMode::Count(ffi_request.response_count)
             }
             FfiTransportResponseMode::UntilTimeout => TransportResponseMode::UntilTimeout,
+        };
+
+        let write_mode = match ffi_request.write_mode {
+            FfiTransportWriteMode::Bulk => TransportWriteMode::Bulk,
+            FfiTransportWriteMode::Control => TransportWriteMode::Control,
         };
 
         let data = if ffi_request.data_ptr.is_null() || ffi_request.data_len == 0 {
@@ -321,6 +327,7 @@ impl FfiEngineAdapter {
         Ok(Some(TransportRequest {
             data,
             response_mode,
+            write_mode,
         }))
     }
 }
@@ -346,30 +353,62 @@ impl Engine for FfiEngineAdapter {
         ))
     }
 
-    fn shutdown_payload(&self) -> Option<Bytes> {
-        let get_fn = self.library.get_shutdown_payload?;
+    fn pop_shutdown_request(&self) -> Option<TransportRequest> {
+        let get_fn = self.library.pop_shutdown_request?;
 
-        let mut buffer = std::mem::MaybeUninit::<FfiApiBuffer>::uninit();
-        let status = unsafe { get_fn(self.handle, buffer.as_mut_ptr()) };
+        let mut shutdown_reqeust = std::mem::MaybeUninit::<FfiTransportRequest>::uninit();
+        let status = unsafe { get_fn(self.handle, shutdown_reqeust.as_mut_ptr()) };
 
         if status != FFI_STATUS_OK {
             return None;
         }
 
-        let mut buffer = unsafe { buffer.assume_init() };
+        let mut ffi_shutdown_request = unsafe { shutdown_reqeust.assume_init() };
 
-        if buffer.data_ptr.is_null() || buffer.data_len == 0 {
-            unsafe { (self.library.free_api_buffer)(&mut buffer) };
+        if ffi_shutdown_request.data_ptr.is_null() || ffi_shutdown_request.data_len == 0 {
+            if let Some(free_request) = self.library.free_transport_request {
+                unsafe {
+                    free_request(&mut ffi_shutdown_request);
+                }
+            }
             return None;
         }
 
+        let free_request = self
+            .library
+            .free_transport_request
+            .expect("engine_free_transport_request is required when transport request is returned");
+
         let data = unsafe {
-            Bytes::copy_from_slice(std::slice::from_raw_parts(buffer.data_ptr, buffer.data_len))
+            Bytes::copy_from_slice(std::slice::from_raw_parts(
+                ffi_shutdown_request.data_ptr,
+                ffi_shutdown_request.data_len,
+            ))
         };
 
-        unsafe { (self.library.free_api_buffer)(&mut buffer) };
+        let response_mode = match ffi_shutdown_request.response_mode {
+            FfiTransportResponseMode::None => TransportResponseMode::None,
+            FfiTransportResponseMode::One => TransportResponseMode::One,
+            FfiTransportResponseMode::Count => {
+                TransportResponseMode::Count(ffi_shutdown_request.response_count)
+            }
+            FfiTransportResponseMode::UntilTimeout => TransportResponseMode::UntilTimeout,
+        };
 
-        Some(data)
+        let write_mode = match ffi_shutdown_request.write_mode {
+            FfiTransportWriteMode::Bulk => TransportWriteMode::Bulk,
+            FfiTransportWriteMode::Control => TransportWriteMode::Control,
+        };
+
+        unsafe {
+            free_request(&mut ffi_shutdown_request);
+        }
+
+        Some(TransportRequest {
+            data,
+            response_mode,
+            write_mode,
+        })
     }
 }
 
@@ -418,9 +457,9 @@ impl Engine for SharedFfiEngineAdapter {
         })
     }
 
-    fn shutdown_payload(&self) -> Option<Bytes> {
+    fn pop_shutdown_request(&self) -> Option<TransportRequest> {
         tokio::task::block_in_place(|| match self.inner.lock() {
-            Ok(adapter) => adapter.shutdown_payload(),
+            Ok(adapter) => adapter.pop_shutdown_request(),
             Err(error) => {
                 tracing::error!("failed to lock ffi engine adapter for shutdown_payload: {error}");
                 None

--- a/core/src/runtime/ffi.rs
+++ b/core/src/runtime/ffi.rs
@@ -116,11 +116,19 @@ pub enum FfiTransportResponseMode {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum FfiTransportWriteMode {
+    Bulk = 0,
+    Control = 1,
+}
+
+#[repr(C)]
 pub struct FfiTransportRequest {
     pub data_ptr: *mut u8,
     pub data_len: usize,
     pub response_mode: FfiTransportResponseMode,
     pub response_count: usize,
+    pub write_mode: FfiTransportWriteMode,
 }
 
 pub type EngineHasTransportRequestFn = unsafe extern "C" fn(handle: EngineHandle) -> bool;
@@ -130,7 +138,7 @@ pub type EnginePopTransportRequestFn =
 
 pub type EngineFreeTransportRequestFn = unsafe extern "C" fn(request: *mut FfiTransportRequest);
 
-/// 종료 시 transport로 전송할 페이로드 조회
-/// 반환값 0: 유효 페이로드, 그 외: 전송 불필요
-pub type EngineGetShutdownPayloadFn =
-    unsafe extern "C" fn(handle: EngineHandle, out_buffer: *mut FfiApiBuffer) -> i32;
+/// 종료 시 transport로 전송할 request 조회
+/// 반환값 0: 유효 request, 그 외: 전송 불필요
+pub type EnginePopShutdownRequestFn =
+    unsafe extern "C" fn(handle: EngineHandle, out_buffer: *mut FfiTransportRequest) -> i32;

--- a/core/src/runtime/loader.rs
+++ b/core/src/runtime/loader.rs
@@ -2,9 +2,9 @@ use libloading::Library;
 
 use crate::runtime::ffi::{
     EngineCallApiFn, EngineCreateFn, EngineDestroyFn, EngineFreeApiBufferFn, EngineFreeFrameFn,
-    EngineFreeTransportRequestFn, EngineGetApiCountFn, EngineGetApiInfoFn,
-    EngineGetShutdownPayloadFn, EngineGetVersionFn, EngineHasFrameFn, EngineHasTransportRequestFn,
-    EnginePopFrameFn, EnginePopTransportRequestFn, EngineProcessPacketFn, EngineSetLoggerFn,
+    EngineFreeTransportRequestFn, EngineGetApiCountFn, EngineGetApiInfoFn, EngineGetVersionFn,
+    EngineHasFrameFn, EngineHasTransportRequestFn, EnginePopFrameFn, EnginePopShutdownRequestFn,
+    EnginePopTransportRequestFn, EngineProcessPacketFn, EngineSetLoggerFn,
 };
 
 /// 외부 공유 라이브러리 핸들 및 FFI 함수 포인터 구조체
@@ -25,7 +25,7 @@ pub struct EngineLibrary {
     pub has_transport_request: Option<EngineHasTransportRequestFn>,
     pub pop_transport_request: Option<EnginePopTransportRequestFn>,
     pub free_transport_request: Option<EngineFreeTransportRequestFn>,
-    pub get_shutdown_payload: Option<EngineGetShutdownPayloadFn>,
+    pub pop_shutdown_request: Option<EnginePopShutdownRequestFn>,
 }
 
 impl EngineLibrary {
@@ -74,9 +74,9 @@ impl EngineLibrary {
                 .map(|symbol| *symbol)
         };
 
-        let get_shutdown_payload = unsafe {
+        let pop_shutdown_request = unsafe {
             library
-                .get::<EngineGetShutdownPayloadFn>(b"engine_get_shutdown_payload")
+                .get::<EnginePopShutdownRequestFn>(b"engine_pop_shutdown_request")
                 .ok()
                 .map(|symbol| *symbol)
         };
@@ -98,7 +98,7 @@ impl EngineLibrary {
             has_transport_request,
             pop_transport_request,
             free_transport_request,
-            get_shutdown_payload,
+            pop_shutdown_request,
         })
     }
 }

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -47,10 +47,17 @@ impl Default for TransportResponseMode {
 }
 
 /// 트랜스포트로 전송할 원시 데이터 청크
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportWriteMode {
+    Bulk,
+    Control,
+}
+
 #[derive(Debug, Clone)]
 pub struct TransportRequest {
     pub data: Bytes,
     pub response_mode: TransportResponseMode,
+    pub write_mode: TransportWriteMode,
 }
 
 pub trait Transport {

--- a/core/src/transport/usb.rs
+++ b/core/src/transport/usb.rs
@@ -13,7 +13,7 @@ use rusb::{DeviceHandle, GlobalContext};
 use crate::config::UsbTransportRuntimeConfig;
 use crate::transport::{
     Transport, TransportChunk, TransportFuture, TransportId, TransportKind, TransportRequest,
-    TransportResponseMode,
+    TransportResponseMode, TransportWriteMode,
 };
 
 /// USB 장치를 기존 Engine FFI의 sender_addr 구조에 맞추기 위한 synthetic address
@@ -106,6 +106,55 @@ impl UsbTransport {
             self.config.vendor_id, self.config.product_id, self.config.interface
         )
     }
+
+    fn write_control_setup(&mut self, data: &[u8]) -> io::Result<usize> {
+        if data.len() < 8 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "control setup must be at least 8 bytes",
+            ));
+        }
+
+        let bm = data[0];
+        let req = data[1];
+        let value = u16::from_le_bytes([data[2], data[3]]);
+        let index = u16::from_le_bytes([data[4], data[5]]);
+        let length = u16::from_le_bytes([data[6], data[7]]) as usize;
+        let payload = &data[8..];
+
+        if payload.len() != length {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "control payload length mismatch: wLength={}, payload={}",
+                    length,
+                    payload.len()
+                ),
+            ));
+        }
+
+        let written = self
+            .handle
+            .write_control(bm, req, value, index, payload, self.transact_timeout)
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("USB control write failed: {error}"),
+                )
+            })?;
+
+        if written != length {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                format!(
+                    "USB control write incomplete: written={}, expected={}",
+                    written, length
+                ),
+            ));
+        }
+
+        Ok(written)
+    }
 }
 
 impl Transport for UsbTransport {
@@ -157,29 +206,37 @@ impl Transport for UsbTransport {
     ) -> TransportFuture<'_, Vec<TransportChunk>> {
         Box::pin(async move {
             tokio::task::block_in_place(|| {
-                let written = self
-                    .handle
-                    .write_bulk(
-                        self.config.endpoint_out,
-                        &request.data,
-                        self.transact_timeout,
-                    )
-                    .map_err(|error| {
-                        io::Error::new(
-                            io::ErrorKind::Other,
-                            format!("USB bulk write failed: {error}"),
-                        )
-                    })?;
+                match request.write_mode {
+                    TransportWriteMode::Bulk => {
+                        let written = self
+                            .handle
+                            .write_bulk(
+                                self.config.endpoint_out,
+                                &request.data,
+                                self.transact_timeout,
+                            )
+                            .map_err(|error| {
+                                io::Error::new(
+                                    io::ErrorKind::Other,
+                                    format!("USB bulk write failed: {error}"),
+                                )
+                            })?;
 
-                if written != request.data.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::WriteZero,
-                        format!(
-                            "USB bulk write incomplete: written={}, expected={}",
-                            written,
-                            request.data.len()
-                        ),
-                    ));
+                        if written != request.data.len() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::WriteZero,
+                                format!(
+                                    "USB bulk write incomplete: written={}, expected={}",
+                                    written,
+                                    request.data.len()
+                                ),
+                            ));
+                        }
+                    }
+
+                    TransportWriteMode::Control => {
+                        self.write_control_setup(&request.data)?;
+                    }
                 }
 
                 let expected_response_count = match request.response_mode {


### PR DESCRIPTION
- transport request에 `Bulk`와 `Control` write mode를 추가
- FFI를 통해 엔진이 요청별 USB 전송 방식을 지정할 수 있도록 확장
- USB control setup packet을 파싱해 `write_control`로 전송하도록 구현
- shutdown payload를 `TransportRequest` 기반의 다중 shutdown request 처리 방식으로 개선